### PR TITLE
Update NixOS Wiki link

### DIFF
--- a/network.nix
+++ b/network.nix
@@ -27,7 +27,7 @@
   hardware.bluetooth.powerOnBoot = true;
   # Using Bluetooth headset buttons to control media player
   # TODO: Try home manager service
-  # https://nixos.wiki/wiki/Bluetooth
+  # https://wiki.nixos.org/wiki/Bluetooth
   systemd.user.services.mpris-proxy = {
     description = "Mpris proxy";
     after = [ "network.target" "sound.target" ];

--- a/nvidia.nix
+++ b/nvidia.nix
@@ -1,6 +1,6 @@
 { pkgs, lib, config, ... }:
 
-# https://nixos.wiki/wiki/Nvidia
+# https://wiki.nixos.org/wiki/Nvidia
 let
   nvidia-offload = pkgs.writeShellScriptBin "nvidia-offload" ''
     export __NV_PRIME_RENDER_OFFLOAD=1

--- a/syncthing.nix
+++ b/syncthing.nix
@@ -1,6 +1,6 @@
 {pkgs, ...}:
 {
-  # https://nixos.wiki/wiki/Syncthing
+  # https://wiki.nixos.org/wiki/Syncthing
   services = {
     syncthing = {
       enable = true;


### PR DESCRIPTION
Hello there 👋!

The NixOS wiki is in the process of migrating from https://nixos.wiki to https://wiki.nixos.org.
You can find more information about it [here](https://github.com/NixOS/foundation/issues/113).

You seem to be using the old link in your repository, which is why we send you this PR.
If you feel like this is not correct or have any questions, feel free to [get in touch with us](https://github.com/NixOS/nixos-wiki-infra/issues/105).


Have a great day,

-- The NixOS Wiki-Team ❄️